### PR TITLE
📝 Fix wrong deploy action names

### DIFF
--- a/pages/docs/WordpressIntegration/actions-and-filters.mdx
+++ b/pages/docs/WordpressIntegration/actions-and-filters.mdx
@@ -32,30 +32,30 @@ add_action('wpbones_console_deploy_start', function ($console, $path) {
 }, 10, 2);
 ```
 
-### wpbones_console_deploy_before_compile_assets
+### wpbones_console_deploy_before_build_assets
 
 ```php copy
 /**
-* Fired before compile assets
+* Fired before building assets
 *
 * @param object $console Instance of WPBones Console
 * @param string $path Destination path
 */
-add_action('wpbones_console_deploy_before_compile_assets', function ($console, $path) {
+add_action('wpbones_console_deploy_before_build_assets', function ($console, $path) {
     // Do something
 }, 10, 2);
 ```
 
-### wpbones_console_deploy_after_compile_assets
+### wpbones_console_deploy_after_build_assets
 
 ```php copy
 /**
-* Fired after compile assets
+* Fired after building assets
 *
 * @param object $console Instance of WPBones Console
 * @param string $path Destination path
 */
-add_action('wpbones_console_deploy_after_compile_assets', function ($console, $path) {
+add_action('wpbones_console_deploy_after_build_assets', function ($console, $path) {
     // Do something
 }, 10, 2);
 ```


### PR DESCRIPTION
WP Bones deploy action names were changed sometime but it wasn't followed in the documentation and the WP Kirk's `deploy.php`.

See also: https://github.com/wpbones/WPKirk/pull/15