### PR TITLE
Update eloquent-orm.mdx

### DIFF
--- a/pages/docs/DatabaseORM/eloquent-orm.mdx
+++ b/pages/docs/DatabaseORM/eloquent-orm.mdx
@@ -25,6 +25,10 @@ You can install Eloquent ORM in your plugin by using
 ```sh copy
 composer install illuminate/database
 ```
+Also you need to include [laravel/serializable-closure](https://github.com/laravel/serializable-closure) in order to serialize objects for debug and to avoid errors on save instances of your model.
+```sh copy
+composer require laravel/serializable-closure
+```
 
 <Callout type="info">
 We decided to remove the illuminate/database Eloquent ORM package from the WP Bones core because it could cause some issues in the WordPress environment.


### PR DESCRIPTION
When you don't use the `laravel/serializable-closure` package you will get a fatal error when you save the model.
```php
PHP Fatal error:  Uncaught Error: Class "Laravel\SerializableClosure\Support\ReflectionClosure" not found in [...]
```
