### PR TITLE
updated info for CPT page

### DIFF
--- a/pages/docs/DatabaseORM/seeding.mdx
+++ b/pages/docs/DatabaseORM/seeding.mdx
@@ -86,7 +86,7 @@ return new class extends Seeder {
       VALUES
       	(1,'','Mauritania','MR','Mauritanian Ouguiya','','','MRO',0.00,'africa','publish')");
   }
-}
+};
 ```
 
 ## WordPress prefix
@@ -130,7 +130,7 @@ return new class extends Seeder {
       VALUES
       	(1,'','Mauritania','MR','Mauritanian Ouguiya','','','MRO',0.00,'africa','publish')");
   }
-}
+};
 ```
 
 In this case the table name will be `my_plugin_products`.
@@ -169,7 +169,7 @@ return new class extends Seeder {
       ]
     );
   }
-}
+};
 ```
 ### Remove the WordPress prefix
 
@@ -208,7 +208,7 @@ return new class extends Seeder {
       ]
     );
   }
-}
+};
 ```
 
 In the Model class, you have to set to false the second parameter of the `DB::getTableName` method.

--- a/pages/docs/ServicesProvider/custom-post-types.mdx
+++ b/pages/docs/ServicesProvider/custom-post-types.mdx
@@ -56,6 +56,31 @@ class MyCustomPostType extends WordPressCustomPostTypeServiceProvider {
   protected $plural = 'Starships';
 
   /**
+   * Whether to include the post type in the REST API.
+   * Set this to true for the post type to be available in the block editor.
+   *
+   * @var bool
+   */
+  protected $showInRest = true;
+
+ /**
+   * Whether to generate a default UI for managing this post type in the admin.
+   * If not set, the default is inherited from public.
+   *
+   * @var bool
+   */
+  protected $showUI     = true;
+
+  /**
+   * An alias for calling add_post_type_support() directly. Defaults to title and editor.
+   * See {@link add_post_type_support()} for documentation.
+   *
+   * @var array
+   */
+  protected $supports   = ['title', 'editor', 'thumbnail', 'excerpt']; // etc..
+
+
+  /**
    * You may override this method in order to register your own actions and filters.
    *
    */

--- a/pages/docs/ServicesProvider/custom-taxonomy-types.mdx
+++ b/pages/docs/ServicesProvider/custom-taxonomy-types.mdx
@@ -56,3 +56,27 @@ Add this new Service Provider to the list of providers in the `/config/plugin.ph
 
   'custom_taxonomy_types' => [ '\WPKirk\CustomTaxonomyTypes\MyCustomTaxonomy' ],
 ```
+
+## Columns
+You may add columns to your Custom Taxonomy Type by adding the following code to your Service Provider:
+```php filename="plugin/CustomTaxonomyTypes/MyCustomTaxonomy.php" copy
+public function registerColumns()
+{
+  return [
+    'my_new_column_name' => 'Column Name',       
+  ];
+}
+```
+
+and also set the Column Content (where you can process the output), is *mandatory* to use `return` and not an `echo` statement
+
+```php filename="plugin/CustomTaxonomyTypes/MyCustomTaxonomy.php" copy
+public function columnContent($string, $column_name, $term_id)
+  {
+  if ($column_name === 'my_new_column_name') {
+      //... your logic here
+      return 'your_new_content_here';
+    }
+    return $string;
+  }
+```


### PR DESCRIPTION
Add extra code to Custom Post Type to allow to be viewed and used in Admin Panel.

https://www.wpbones.com/docs/ServicesProvider/custom-post-types

Add info for support WP fields with the CPT.
