### PR TITLE
🐛 fix(release-notes): resilient GitHub API fetch

### DIFF
--- a/app/api/github-releases/route.ts
+++ b/app/api/github-releases/route.ts
@@ -14,19 +14,44 @@ export async function GET(request: Request) {
       return Response.json({ error: 'Bots are not allowed' }, { status: 403 });
     }
 
-    const response = await fetch(
-      `${config.gitHub.releasesUrl}?per_page=${config.releaseNotes.maxReleases}`,
-      {
-        headers: {
-          Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`, // Optional for rate limit
-        },
+    const url = `${config.gitHub.releasesUrl}?per_page=${config.releaseNotes.maxReleases}`;
+    const baseHeaders: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'wpbones-docs-site',
+    };
+
+    // Try authenticated first if a token is configured (5000 req/hour vs 60/hour).
+    // If the token is invalid/expired (401) or rejected by org policy (403, e.g.
+    // fine-grained tokens with too-long lifetime), retry unauthenticated instead
+    // of failing — public releases are readable without auth.
+    let response: Response;
+    if (process.env.GITHUB_TOKEN) {
+      response = await fetch(url, {
+        headers: { ...baseHeaders, Authorization: `Bearer ${process.env.GITHUB_TOKEN}` },
+      });
+      if (response.status === 401 || response.status === 403) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `GITHUB_TOKEN returned ${response.status} — falling back to unauthenticated fetch`
+        );
+        response = await fetch(url, { headers: baseHeaders });
       }
-    );
+    } else {
+      response = await fetch(url, { headers: baseHeaders });
+    }
 
     if (!response.ok) {
+      const bodyText = await response.text();
+      const rateRemaining = response.headers.get('x-ratelimit-remaining');
+      const rateReset = response.headers.get('x-ratelimit-reset');
       // eslint-disable-next-line no-console
-      console.error('Error fetching releases:', response.statusText);
+      console.error('[github-releases] non-OK response', {
+        status: response.status,
+        statusText: response.statusText,
+        rateRemaining,
+        rateReset,
+        body: bodyText.slice(0, 300),
+      });
       return Response.json(response.statusText, { status: response.status });
     }
 

--- a/components/ReleaseNotes/use-release-notes.ts
+++ b/components/ReleaseNotes/use-release-notes.ts
@@ -66,6 +66,11 @@ export function useReleaseNotes() {
         return;
       }
 
+      if (!data.releases || !Array.isArray(data.releases)) {
+        setError('Unexpected response from /api/github-releases. Check the server logs.');
+        return;
+      }
+
       const fetchReleases = async () => {
         const releases = await Promise.all(
           data.releases.map(async (release) => ({


### PR DESCRIPTION
## Problem

The release notes page on wpbones.com showed "Loading releases…" indefinitely.

Root causes (two separate bugs stacked):

1. **`Authorization: Bearer undefined`** when `GITHUB_TOKEN` env var is not set — GitHub responds 401.
2. **The configured token returns 403** because it's a fine-grained PAT with lifetime > 366 days, which the `wpbones` org forbids by policy. The old fallback only handled 401, not 403, so the retry never kicked in.
3. On the client, `data.releases.map()` crashed with `Cannot read properties of undefined` when the API returned a plain string body (e.g. `"Forbidden"`), leaving the UI stuck on the loader.

## Fix

`app/api/github-releases/route.ts`:
- Attach `Authorization` header only when the env var is truthy.
- On `401` or `403` from an authenticated request, retry unauthenticated (public releases don't need auth).
- Send a proper `User-Agent` (GitHub requires it on unauth requests).
- Log full error body + `x-ratelimit-*` headers when GitHub returns non-OK — makes future issues diagnosable.

`components/ReleaseNotes/use-release-notes.ts`:
- Guard against non-array `data.releases` and surface a clear error in the UI instead of crashing.

## Verified locally

- `yarn dev`, curl `/api/github-releases` → `{ status: 'ok', releases: [10 items starting with v1.11.1] }`.
- Error path tested by intentionally invalid token — server logs the real GitHub message and the client falls back to unauthenticated, returning the list.

## Follow-up for repo owner

The fine-grained PAT (token id `13606202`) needs to be regenerated with lifetime ≤ 366 days and the `wpbones` org re-approved, then re-set on Vercel as `GITHUB_TOKEN`. Until then the site works via the unauth fallback at 60 req/hour/IP (Vercel-wide), which may intermittently rate-limit under heavy traffic.