### PR TITLE
🚀 chore(release): bump docs site to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "test": "yarn next typegen && yarn format:test && yarn lint && yarn typecheck && yarn jest",
     "typecheck": "tsc --noEmit"
   },
-  "version": "1.11.1"
+  "version": "2.0.1"
 }


### PR DESCRIPTION
Aligns the `package.json` version with the current framework release so the Nextra header (via `app/layout.tsx` importing the package version) stops showing 1.11.1.