### PR TITLE
🧹 chore(blueprints): pluginZipFile → pluginData

### DIFF
--- a/public/blueprint.json
+++ b/public/blueprint.json
@@ -18,7 +18,7 @@
         },
         {
             "step": "installPlugin",
-            "pluginZipFile": {
+            "pluginData": {
                 "resource": "url",
                 "url": "https://wpbones.com/wpkirk.zip"
             },

--- a/public/wpkirk-api-boilerplate.json
+++ b/public/wpkirk-api-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-api-boilerplate.zip"
       },

--- a/public/wpkirk-blade-boilerplate.json
+++ b/public/wpkirk-blade-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-blade-boilerplate.zip"
       },

--- a/public/wpkirk-boilerplate.json
+++ b/public/wpkirk-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-boilerplate.zip"
       },

--- a/public/wpkirk-cpt-boilerplate.json
+++ b/public/wpkirk-cpt-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-cpt-boilerplate.zip"
       },

--- a/public/wpkirk-cron-boilerplate.json
+++ b/public/wpkirk-cron-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-cron-boilerplate.zip"
       },

--- a/public/wpkirk-database-boilerplate.json
+++ b/public/wpkirk-database-boilerplate.json
@@ -18,7 +18,7 @@
         },
         {
             "step": "installPlugin",
-            "pluginZipFile": {
+            "pluginData": {
                 "resource": "url",
                 "url": "https://www.wpbones.com/wpkirk-database-boilerplate.zip"
             },

--- a/public/wpkirk-demo.json
+++ b/public/wpkirk-demo.json
@@ -18,7 +18,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-demo.zip"
       },

--- a/public/wpkirk-hooks-boilerplate.json
+++ b/public/wpkirk-hooks-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-hooks-boilerplate.zip"
       },

--- a/public/wpkirk-internationalization-boilerplate.json
+++ b/public/wpkirk-internationalization-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-internationalization-boilerplate.zip"
       },

--- a/public/wpkirk-mantine-boilerplate.json
+++ b/public/wpkirk-mantine-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-mantine-boilerplate.zip"
       },

--- a/public/wpkirk-options-boilerplate.json
+++ b/public/wpkirk-options-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-options-boilerplate.zip"
       },

--- a/public/wpkirk-packages-boilerplate.json
+++ b/public/wpkirk-packages-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-packages-boilerplate.zip"
       },

--- a/public/wpkirk-reactjs-boilerplate.json
+++ b/public/wpkirk-reactjs-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-reactjs-boilerplate.zip"
       },

--- a/public/wpkirk-routes-boilerplate.json
+++ b/public/wpkirk-routes-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-routes-boilerplate.zip"
       },

--- a/public/wpkirk-typescript-boilerplate.json
+++ b/public/wpkirk-typescript-boilerplate.json
@@ -16,7 +16,7 @@
     },
     {
       "step": "installPlugin",
-      "pluginZipFile": {
+      "pluginData": {
         "resource": "url",
         "url": "https://www.wpbones.com/wpkirk-typescript-boilerplate.zip"
       },


### PR DESCRIPTION
Removes the Playground deprecation warning logged on every blueprint load by renaming the `installPlugin` step option as recommended upstream. Functional behaviour is unchanged.

16 files updated in one pass.