### PR TITLE
📝 docs(v2): fix v2 migration workflow

### DIFF
--- a/content/migrating-to-v2.mdx
+++ b/content/migrating-to-v2.mdx
@@ -107,7 +107,7 @@ composer update
 php bones migrate:to-v2
 ```
 
-You'll see a `Y/N` prompt summarising what it will touch. Say `Y`.
+You'll see a `y/N` prompt summarising what it will touch. Say `y`.
 
 ### Reinstall and build
 

--- a/content/migrating-to-v2.mdx
+++ b/content/migrating-to-v2.mdx
@@ -95,18 +95,23 @@ Edit `composer.json`:
 }
 ```
 
+### Update dependencies
+
+```sh copy
+composer update
+```
+
 ### Run the migrator
 
 ```sh copy
 php bones migrate:to-v2
 ```
 
-You'll see a `y/N` prompt summarising what it will touch. Say `y`.
+You'll see a `Y/N` prompt summarising what it will touch. Say `Y`.
 
 ### Reinstall and build
 
 ```sh copy
-composer update
 yarn install
 yarn build
 ```


### PR DESCRIPTION
The `php bones migrate:to-v2` command only exists in versions above 2.0.0. If you don't update the dependencies first, you will get an unknown command error.