### PR TITLE
📝 docs: clarify that v2 boilerplates are yarn-first but PM-agnostic

### DIFF
--- a/content/core-concepts/architecture-foundations.mdx
+++ b/content/core-concepts/architecture-foundations.mdx
@@ -244,7 +244,7 @@ Also, you will find a set of files in the root of the plugin:
 - The `webpack.config.js`, `tsconfig.json`, `jest.config.js` and `.prettierrc` make up the v2 build + tooling pipeline. See [`webpack.config.js`](/docs/core-plugin-files/webpack-config) for the auto-discovery rules.
 - The `{your-plugin-name}.php` is the entry point of the plugin.
 - The `namespace` is a file used by the bones command. You can ignore it.
-- The `package.json` is used by npm. Feel free to add your own packages.
+- The `package.json` is used by your JavaScript package manager (yarn, npm or pnpm — the v2 boilerplates are yarn-first but PM-agnostic). Feel free to add your own packages.
 - The `readme.txt` is the WordPress readme file to be used when you'll submit your plugin to the WordPress repository.
 
 ### The plugin directory

--- a/content/getting-started/requirements.mdx
+++ b/content/getting-started/requirements.mdx
@@ -2,9 +2,10 @@ import { Callout } from 'nextra/components';
 
 # Requirements
 
-WP Bones requires **PHP ≥ 8.1**, **git**, **Composer**, **Node.js** with **yarn** (or npm), and
-optionally **WP-CLI**. The `php bones` command must run inside a working WordPress install — a
-local dev environment like Laravel Valet, Local, Lando, Docker, or WordPress Playground all work.
+WP Bones requires **PHP ≥ 8.1**, **git**, **Composer**, **Node.js** with a package manager
+(**yarn**, npm or pnpm), and optionally **WP-CLI**. The `php bones` command must run inside a
+working WordPress install — a local dev environment like Laravel Valet, Local, Lando, Docker,
+or WordPress Playground all work.
 
 ## Developer tools
 
@@ -14,7 +15,9 @@ If you are new to [Composer](https://getcomposer.org/), [Node.js / yarn](https:/
 - PHP ≥ 8.1
 - [git](https://git-scm.com/)
 - [Composer](https://getcomposer.org/)
-- [Node.js 18+](https://nodejs.org/) with [yarn](https://yarnpkg.com/) (recommended) or npm
+- [Node.js 18+](https://nodejs.org/) with [yarn](https://yarnpkg.com/) (recommended — v2
+  boilerplates ship a committed `yarn.lock`), [npm](https://www.npmjs.com/) or
+  [pnpm](https://pnpm.io/)
 - [WP-CLI](https://wp-cli.org/#installing) (optional but recommended)
 
 <Callout>

--- a/content/int-locale/reactjs-apps.mdx
+++ b/content/int-locale/reactjs-apps.mdx
@@ -12,7 +12,7 @@ This document explains how to localize ReactJS applications in WP Bones. It cove
 ## Overview
 
 Before you start, make sure you have installed [WP-CLI](https://make.wordpress.org/cli/handbook/guides/installing/).
-That's because you will need to use the new npm scripts for the localization.
+That's because you will need to use the new `package.json` scripts for the localization.
 
 <Callout type="error">
 If you want to localize your ReactJS application, you won't be able to use the `lazy` import. That's because the wp-script will generate several files, for example `437.js`, which won't be able to be localized.

--- a/content/migrating-to-v2.mdx
+++ b/content/migrating-to-v2.mdx
@@ -143,6 +143,18 @@ The v2 boilerplates are **yarn-first** — they ship a committed `yarn.lock` and
   produce identical output.
 - `php bones deploy --pkgm=<pm>` already accepts `yarn`, `npm` or `pnpm`.
 
+### Why yarn-first?
+
+The choice is pragmatic rather than technical: WP Bones and a few adjacent React/TS
+projects maintained by the same author (including the dedicated Mantine boilerplate)
+standardize on yarn so tooling, CI, and day-to-day commands stay consistent across the
+ecosystem. It is **not** a claim that yarn is technically superior — pnpm, for instance,
+has excellent benchmarks and strict dependency resolution. If community preference
+shifts, swapping the committed lockfile is a non-event and shipping multiple lockfiles
+as equally first-class remains on the table.
+
+### How to use a different PM
+
 If you want to keep using the package manager you had in your v1.x plugin (or switch to a new
 one), the migrator has your back: it detects your lockfile (`yarn.lock`, `pnpm-lock.yaml` or
 `package-lock.json`) **before** deleting it, and the printed "Next steps" match the PM you were

--- a/content/migrating-to-v2.mdx
+++ b/content/migrating-to-v2.mdx
@@ -111,6 +111,12 @@ You'll see a `y/N` prompt summarising what it will touch. Say `y`.
 
 ### Reinstall and build
 
+The migrator deletes your previous lockfile (`package-lock.json` or `pnpm-lock.yaml`) so you
+can pick up a clean one. The "Next steps" it prints at the end use the package manager it
+detected in your project before deletion — yarn, npm or pnpm — so you don't have to switch
+tools unless you want to. The snippets below assume yarn (the v2 default); see
+[Using npm or pnpm instead of yarn](#using-npm-or-pnpm-instead-of-yarn) if you use a different PM.
+
 ```sh copy
 yarn install
 yarn build
@@ -125,6 +131,32 @@ Open the plugin's admin page in WordPress. Any React app you had under
 yarn test   # if you had tests
 ```
 </Steps>
+
+## Using npm or pnpm instead of yarn
+
+The v2 boilerplates are **yarn-first** — they ship a committed `yarn.lock` and the CLI's
+"Next steps" default to `yarn` — but there is no technical lock-in on yarn:
+
+- `package.json` has no `packageManager`, `engines` or `resolutions` fields.
+- There is no `.yarnrc.yml`, `.npmrc` or `.pnpmrc`.
+- All scripts are `wp-scripts <verb>`, so `npm run build`, `pnpm build` and `yarn build`
+  produce identical output.
+- `php bones deploy --pkgm=<pm>` already accepts `yarn`, `npm` or `pnpm`.
+
+If you want to keep using the package manager you had in your v1.x plugin (or switch to a new
+one), the migrator has your back: it detects your lockfile (`yarn.lock`, `pnpm-lock.yaml` or
+`package-lock.json`) **before** deleting it, and the printed "Next steps" match the PM you were
+already using. Just run the commands it prints, and you're done.
+
+Starting from a freshly cloned boilerplate and want to use npm or pnpm instead of yarn? Delete
+the committed `yarn.lock`, then `npm install` or `pnpm install`. The scripts in `package.json`
+will work as-is with any of the three package managers.
+
+> **Note:** pick one PM per plugin and stick with it. Mixing lockfiles in the same repo
+> (`yarn.lock` + `package-lock.json`) quickly leads to drift between what CI installs and
+> what you get locally.
+
+## Migrating apps that used per-script entries
 
 ## Migrating apps that used per-script entries
 
@@ -175,13 +207,14 @@ at least WP Bones `v1.11.1`.
 
 ## Rollback
 
-If something doesn't work, roll back via git:
+If something doesn't work, roll back via git and reinstall dependencies with your original
+package manager:
 
 ```sh copy
 git reset --hard HEAD
 rm -rf node_modules vendor
 composer install
-npm install   # v1.x path
+yarn install    # or: npm install / pnpm install
 ```
 
 Then open an issue with the error output and we'll help.

--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "test": "yarn next typegen && yarn format:test && yarn lint && yarn typecheck && yarn jest",
     "typecheck": "tsc --noEmit"
   },
-  "version": "2.0.1"
+  "version": "2.0.2"
 }


### PR DESCRIPTION
## Summary

Answers [feedback from the Discord community](https://github.com/wpbones/WPBones/issues/77) about npm mentions scattered throughout the docs after the v2.0.0 release. The correct fix is not "remove every mention of npm" — the v2 boilerplates have no technical lock-in on yarn — but rather to explicitly document the **yarn-first but PM-agnostic** stance so users who were on npm or pnpm before aren't left wondering whether they need to switch.

## Changes

- **`getting-started/requirements.mdx`** — list yarn, npm, pnpm as first-class alternatives. Yarn stays "recommended" because the boilerplates ship a committed `yarn.lock`.
- **`core-concepts/architecture-foundations.mdx`** — `package.json` described as consumed by "your JavaScript package manager" rather than npm specifically.
- **`int-locale/reactjs-apps.mdx`** — replace "npm scripts" with "package.json scripts" (neutral and technically accurate — they are scripts in package.json).
- **`migrating-to-v2.mdx`**:
  - new section **"Using npm or pnpm instead of yarn"** that explains the PM-agnostic stance
  - clarifies that `migrate:to-v2` detects the developer's lockfile **before** deletion and suggests matching "Next steps" commands (paired with framework PR wpbones/WPBones#78)
  - cleans up the rollback snippet that hard-coded `npm install`
- **`package.json`** — bump to `2.0.2` to track the framework release.

## What's left **untouched** (on purpose)

- `migrating-to-v2.mdx` line mentioning `npm-run-all` → literal npm package name being removed from devDependencies. Must stay.
- `bones-console.mdx` help of `--pkgm=<package-manager>` flag → `askPackageManager()` in the CLI still supports yarn/npm/pnpm; the example is correct.
- `versioning.mdx` URL to `github.com/npm/node-semver` → literal GitHub account of the maintainer.
- `before-submit-to-wordpress-repository.mdx` quotes from WordPress.org guidelines → external citations, verbatim.

## Test plan
- [x] `yarn test` passes locally
- [x] `yarn build` succeeds locally (pagefind rebuilt, 76 pages indexed)
- [ ] Vercel preview deploy
- [ ] Visual check on the new "Using npm or pnpm instead of yarn" anchor in the migration page

Refs wpbones/WPBones#77