### PR TITLE
🔖 chore: bump site version to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "test": "yarn next typegen && yarn format:test && yarn lint && yarn typecheck && yarn jest",
     "typecheck": "tsc --noEmit"
   },
-  "version": "2.0.2"
+  "version": "2.0.3"
 }


### PR DESCRIPTION
## Summary

Aligns the docs site version with the framework [v2.0.3 release](https://github.com/wpbones/WPBones/releases/tag/v2.0.3).

Framework v2.0.3 was cut right after v2.0.2 to address three Copilot-review follow-ups:
- Corrected post-migration guidance (lockfile deletion wording)
- Bumped internal `WPBONES_COMMAND_LINE_VERSION` constant
- Style cleanup in `detectProjectPackageManager()`

See wpbones/WPBones#79 for details.

## Test plan
- [x] `yarn test` passes locally
- [x] `yarn build` succeeds locally