### PR TITLE
📝 docs: make the mix-PM warning a Callout in migrating-to-v2

### DIFF
--- a/content/migrating-to-v2.mdx
+++ b/content/migrating-to-v2.mdx
@@ -164,9 +164,11 @@ Starting from a freshly cloned boilerplate and want to use npm or pnpm instead o
 the committed `yarn.lock`, then `npm install` or `pnpm install`. The scripts in `package.json`
 will work as-is with any of the three package managers.
 
-> **Note:** pick one PM per plugin and stick with it. Mixing lockfiles in the same repo
-> (`yarn.lock` + `package-lock.json`) quickly leads to drift between what CI installs and
-> what you get locally.
+<Callout type="warning">
+  **Pick one PM per plugin and stick with it.** Mixing lockfiles in the same repo
+  (`yarn.lock` + `package-lock.json`) quickly leads to drift between what CI installs
+  and what you get locally.
+</Callout>
 
 ## Migrating apps that used per-script entries
 


### PR DESCRIPTION
## Summary

In the "Using npm or pnpm instead of yarn" section of `migrating-to-v2.mdx`, the advice to not mix lockfiles in the same repo was a plain markdown blockquote — easy to miss inside a wall of text.

Swap it for Nextra's `<Callout type="warning">` (same component already used in `requirements.mdx`) so the warning is visually distinct.

## Test plan
- [x] `yarn test` passes locally
- [x] `yarn build` succeeds locally