### PR TITLE
perf: block AI scrapers + cache GitHub releases response

### DIFF
--- a/app/api/github-releases/route.ts
+++ b/app/api/github-releases/route.ts
@@ -24,9 +24,11 @@ export async function GET(request: Request) {
     // If the token is invalid/expired (401) or rejected by org policy (403, e.g.
     // fine-grained tokens with too-long lifetime), retry unauthenticated instead
     // of failing — public releases are readable without auth.
+    const fetchOptions = { next: { revalidate: 3600 } };
     let response: Response;
     if (process.env.GITHUB_TOKEN) {
       response = await fetch(url, {
+        ...fetchOptions,
         headers: { ...baseHeaders, Authorization: `Bearer ${process.env.GITHUB_TOKEN}` },
       });
       if (response.status === 401 || response.status === 403) {
@@ -34,10 +36,10 @@ export async function GET(request: Request) {
         console.warn(
           `GITHUB_TOKEN returned ${response.status} — falling back to unauthenticated fetch`
         );
-        response = await fetch(url, { headers: baseHeaders });
+        response = await fetch(url, { ...fetchOptions, headers: baseHeaders });
       }
     } else {
-      response = await fetch(url, { headers: baseHeaders });
+      response = await fetch(url, { ...fetchOptions, headers: baseHeaders });
     }
 
     if (!response.ok) {
@@ -57,7 +59,14 @@ export async function GET(request: Request) {
 
     const releases = await response.json();
 
-    return Response.json({ releases, status: 'ok' });
+    return Response.json(
+      { releases, status: 'ok' },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+        },
+      }
+    );
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.error('Error checking user agent:', error);

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,97 @@
+# https://www.wpbones.com/robots.txt
+#
+# Search engines are welcome.
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Slurp
+Allow: /
+
+User-agent: Baiduspider
+Allow: /
+
+User-agent: YandexBot
+Allow: /
+
+# Block AI training / scraping crawlers (high CDN cost, no SEO value)
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Perplexity-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Meta-ExternalFetcher
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: DuckAssistBot
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: omgilibot
+Disallow: /
+
+# Default rule for everything else
+User-agent: *
+Allow: /


### PR DESCRIPTION
## Summary

- Vercel ISR Read Units on `wpbones-website-docs` were ~628k in the last ~28 days (75% of org total). Pattern was a flat ~20k/day with no spikes → consistent with AI scrapers crawling all 76 prerendered docs pages every day, not real user traffic.
- The Nextra MDX route is already `force-static` + `revalidate: false`, so the fix isn't in the rendering layer — it's in **stopping bot crawls** and **caching the only dynamic call** (GitHub releases).

## Changes

### `public/robots.txt` (new)

Explicit `Disallow: /` for the AI-training and scraper bots that account for the bulk of unwanted traffic:

GPTBot · ChatGPT-User · OAI-SearchBot · ClaudeBot · Claude-Web · anthropic-ai · PerplexityBot · Perplexity-User · Google-Extended · Applebot-Extended · Bytespider · CCBot · Amazonbot · Meta-ExternalAgent · Meta-ExternalFetcher · FacebookBot · ImagesiftBot · DuckAssistBot · YouBot · cohere-ai · Diffbot · Timpibot · omgili · omgilibot

Real search engines stay allowed (Googlebot, Bingbot, DuckDuckBot, Slurp, Baiduspider, YandexBot) so SEO is unaffected. Default `User-agent: *` is `Allow: /`.

### `app/api/github-releases/route.ts`

Two layers of caching for the GitHub API call:

- `next: { revalidate: 3600 }` on the upstream `fetch` → Vercel Data Cache, shared across function instances. The GitHub Releases API gets hit at most once per hour per region, instead of once per user.
- `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400` on the response → the JSON payload is cached at the edge for an hour and served stale-while-revalidate for 24h.

## Test plan

- [x] `yarn test` — green (1 suite, 1 test)
- [x] `yarn build` — green (76 SSG pages, 4 dynamic API routes)
- [ ] Verify `https://www.wpbones.com/robots.txt` returns the file after deploy
- [ ] Check Vercel ISR Reads chart over the next 24-48h for the expected drop
- [ ] Confirm `/docs/release-notes` still lists releases correctly

## Follow-up (not in this PR)

For belt-and-suspenders, also add a **Vercel Firewall** rule from the dashboard:
`Project → Firewall → Rules → "Block AI Bots" → User-Agent matches regex (GPTBot|ClaudeBot|PerplexityBot|Bytespider|CCBot|anthropic-ai|Google-Extended|Applebot-Extended) → Action: Deny`

That catches bots that ignore robots.txt — they'll get a 403 at the edge before consuming any read units.