### PR TITLE
fix: sync package version to framework release 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "test": "yarn next typegen && yarn format:test && yarn lint && yarn typecheck && yarn jest",
     "typecheck": "tsc --noEmit"
   },
-  "version": "2.0.5"
+  "version": "2.0.3"
 }


### PR DESCRIPTION
## Summary

The docs site `package.json` version must mirror the WPBones framework version — latest framework tag is **v2.0.3**.

During recent template updates it was mistakenly bumped to `2.0.4` (0a3633c) and then `2.0.5` (d4a49eb). Since `/api/version` serves `pack.version` straight from `package.json`, the live API (consumed by the **Raycast wpbones extension**) is currently reporting the wrong framework version.

## Changes

- `package.json`: `version` 2.0.5 → 2.0.3

## Test

- `yarn test && yarn build` ✅ (typegen, format, lint, typecheck, jest, production build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)