### PR TITLE
Fix broken docs links in footer and FAQ

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -30,7 +30,7 @@ const faqs: FAQsProps[] = [
     answer: (
       <>
         To start using WP Bones, install the{' '}
-        <Anchor href="/docs/GettingStarted/boilerplate-templates">WP Bones starter plugin</Anchor>{' '}
+        <Anchor href="/docs/getting-started/boilerplate-templates">WP Bones starter plugin</Anchor>{' '}
         in your local WordPress installation.
       </>
     ),
@@ -143,7 +143,7 @@ const faqs: FAQsProps[] = [
             php bones update
           </Pre>{' '}
         </Box>
-        and check the <Anchor href="/docs/CorePluginFiles/overview">Core Plugin Files</Anchor>.
+        and check the <Anchor href="/docs/core-plugin-files/overview">Core Plugin Files</Anchor>.
       </>
     ),
   },

--- a/components/Footer/highlights.ts
+++ b/components/Footer/highlights.ts
@@ -7,22 +7,22 @@ export const highlights = [
   {
     key: 'getting-started',
     title: 'Getting Started',
-    href: '/docs/GettingStarted/requirements',
+    href: '/docs/getting-started/requirements',
   },
   {
     key: 'internationalization',
     title: 'Internationalization',
-    href: '/docs/Internationalization/overview',
+    href: '/docs/int-locale/overview',
   },
   {
     key: 'core-classes',
     title: 'Core Classes',
-    href: '/docs/CoreClasses/overview',
+    href: '/docs/core-classes/overview',
   },
   {
     key: 'core-plugin-files',
     title: 'Core Plugin Files',
-    href: '/docs/CorePluginFiles/overview',
+    href: '/docs/core-plugin-files/overview',
   },
   {
     key: 'faqs',
@@ -32,26 +32,26 @@ export const highlights = [
   {
     key: 'routing',
     title: 'Routing',
-    href: '/docs/CoreConcepts/menus-routing',
+    href: '/docs/core-concepts/menus-routing',
   },
   {
     key: 'blade-templates',
     title: 'Blade Templates',
-    href: '/docs/Views/blade-template',
+    href: '/docs/views-template/blade-template',
   },
   {
     key: 'bones-console',
     title: 'Bones Console',
-    href: '/docs/BonesConsole/bones-console',
+    href: '/docs/bones-console/bones-console',
   },
   {
     key: 'database',
     title: 'Database',
-    href: '/docs/DatabaseORM/query-builder',
+    href: '/docs/database-orm/query-builder',
   },
   {
     key: 'eloquent-orm',
     title: 'Eloquent ORM',
-    href: '/docs/DatabaseORM/eloquent-orm',
+    href: '/docs/database-orm/eloquent-orm',
   },
 ];


### PR DESCRIPTION
## Summary

The `content/` folders were renamed to kebab-case (Nextra 4 migration) but several internal links still pointed to the old PascalCase paths, returning **404**. No redirects exist in `next.config.mjs`, so these were dead links on the live site (verified with curl).

## Changes

**`components/Footer/highlights.ts`** — 9 of 11 HIGHLIGHTS links fixed:

| Link | Before (404) | After (200) |
|---|---|---|
| Getting Started | `/docs/GettingStarted/requirements` | `/docs/getting-started/requirements` |
| Internationalization | `/docs/Internationalization/overview` | `/docs/int-locale/overview` |
| Core Classes | `/docs/CoreClasses/overview` | `/docs/core-classes/overview` |
| Core Plugin Files | `/docs/CorePluginFiles/overview` | `/docs/core-plugin-files/overview` |
| Routing | `/docs/CoreConcepts/menus-routing` | `/docs/core-concepts/menus-routing` |
| Blade Templates | `/docs/Views/blade-template` | `/docs/views-template/blade-template` |
| Bones Console | `/docs/BonesConsole/bones-console` | `/docs/bones-console/bones-console` |
| Database | `/docs/DatabaseORM/query-builder` | `/docs/database-orm/query-builder` |
| Eloquent ORM | `/docs/DatabaseORM/eloquent-orm` | `/docs/database-orm/eloquent-orm` |

**`components/FAQ/FAQ.tsx`** — 2 more links with the same issue:
- `/docs/GettingStarted/boilerplate-templates` → `/docs/getting-started/boilerplate-templates`
- `/docs/CorePluginFiles/overview` → `/docs/core-plugin-files/overview`

All target paths verified against `content/` structure and live site (curl → 200).

## Test plan

- [x] `yarn test` — pass
- [x] `yarn build` — pass
- [x] grep: no PascalCase `/docs/*` paths left in sources